### PR TITLE
Add MSRV and docs.rs metadata to Cargo.toml (#8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "expiration_date"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A professional financial instrument expiration date management library with support for standard day count conventions."
 license = "MIT"
@@ -55,3 +56,7 @@ codegen-units = 1
 
 [profile.dev]
 overflow-checks = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ It supports two representations:
 This is particularly useful in quantitative finance applications where expiration dates
 need to be expressed either as days-to-expiration (DTE) or as specific calendar dates.
 
+### Minimum Supported Rust Version
+
+`expiration_date` requires **Rust 1.85** or later (Edition 2024).
+
 ### Features
 
 - **Dual Representation**: Express expirations as days remaining or absolute datetimes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! # ExpirationDate
 //!
 //! A professional high-performance financial instrument expiration date management library.
@@ -8,6 +9,10 @@
 //! focused submodules: [`cmp`] (hand-written `Hash` / `Eq` / `Ord`),
 //! [`convert`] (day/year accessors, `Display`, `Default`), [`parser`]
 //! (`from_string` and friends), and [`serde_impl`] (hand-written serde).
+//!
+//! ## Minimum Supported Rust Version
+//!
+//! `expiration_date` requires **Rust 1.85** or later (Edition 2024).
 
 /// Hand-written comparison and hashing impls for [`ExpirationDate`].
 pub mod cmp;


### PR DESCRIPTION
## Summary

- `rust-version = "1.85"` declared (Edition 2024 minimum)
- `[package.metadata.docs.rs]` with `all-features=true` so docs.rs renders the optional `utoipa` integration
- `#![cfg_attr(docsrs, feature(doc_cfg))]` on `src/lib.rs`
- README.md and crate docs note the MSRV

Closes #8.

## Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo doc --no-deps --all-features` clean