### PR TITLE
Add Dependabot config for cargo and github-actions (#9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    assignees:
+      - "joaquinbejar"
+    labels:
+      - "deps"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    assignees:
+      - "joaquinbejar"
+    labels:
+      - "deps"
+    groups:
+      gha-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with weekly grouped minor/patch updates for both `cargo` and `github-actions` ecosystems. PRs assigned to `joaquinbejar` with the `deps` label, capped at 10 per ecosystem.

Closes #9.

## Test plan

- [x] No code changes — config file only
- [ ] Verify Dependabot opens organic PRs after merge