### PR TITLE
Add criterion benchmarks for parser, conversion, serde (#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,23 @@ utoipa = { version = "5.4", features = ["chrono", "decimal"], optional = true }
 [dev-dependencies]
 serde_json = { version = "1.0" }
 proptest = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [lib]
 name = "expiration_date"
 path = "src/lib.rs"
+
+[[bench]]
+name = "parser"
+harness = false
+
+[[bench]]
+name = "conversion"
+harness = false
+
+[[bench]]
+name = "serde"
+harness = false
 
 [lints.rust]
 unsafe_code = "deny"

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,13 @@ check-cargo-criterion:
 	@command -v cargo-criterion > /dev/null || cargo install cargo-criterion
 
 .PHONY: bench
-bench: check-cargo-criterion
+bench:
 	@echo "⚡ Running benchmarks..."
+	cargo bench --all-features
+
+.PHONY: bench-criterion
+bench-criterion: check-cargo-criterion
+	@echo "⚡ Running benchmarks via cargo-criterion..."
 	cargo criterion --output-format=quiet
 
 .PHONY: bench-show
@@ -416,7 +421,8 @@ help:
 	@echo "  make coverage        Generate code coverage report (XML)"
 	@echo "  make coverage-html   Generate HTML coverage report"
 	@echo "  make open-coverage   Open HTML report"
-	@echo "  make bench           Run benchmarks using Criterion"
+	@echo "  make bench           Run benchmarks via cargo bench --all-features"
+	@echo "  make bench-criterion Run benchmarks via cargo-criterion"
 	@echo "  make bench-show      Open benchmark report"
 	@echo "  make bench-save      Save benchmark history snapshot"
 	@echo "  make bench-compare   Compare benchmark runs"

--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ We welcome contributions to this project! If you would like to contribute, pleas
 4. Commit your changes and push your branch to your forked repository.
 5. Submit a pull request to the main repository.
 
+### Development
+
+- Run tests: `make test`
+- Lint: `make lint`
+- Format: `make fmt`
+- Run benchmarks: `make bench` (wraps `cargo bench --all-features`; Criterion benches live under `benches/`)
+
 If you have any questions, issues, or would like to provide feedback, please feel free to contact the project maintainer:
 
 

--- a/README.tpl
+++ b/README.tpl
@@ -25,6 +25,13 @@ We welcome contributions to this project! If you would like to contribute, pleas
 4. Commit your changes and push your branch to your forked repository.
 5. Submit a pull request to the main repository.
 
+### Development
+
+- Run tests: `make test`
+- Lint: `make lint`
+- Format: `make fmt`
+- Run benchmarks: `make bench` (wraps `cargo bench --all-features`; Criterion benches live under `benches/`)
+
 If you have any questions, issues, or would like to provide feedback, please feel free to contact the project maintainer:
 
 

--- a/benches/conversion.rs
+++ b/benches/conversion.rs
@@ -1,0 +1,59 @@
+//! Benchmarks for the day / year accessors on [`ExpirationDate`].
+//!
+//! `get_days` and `get_years` sit on the pricing hot path, so this bench
+//! exercises both the `Days` fast path (no `Utc::now` call) and the
+//! `DateTime` variant which pays for a wall-clock read plus the
+//! Actual/365 fixed year fraction.
+
+#![allow(missing_docs)]
+#![allow(clippy::expect_used)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use expiration_date::ExpirationDate;
+
+fn build_datetime_variant() -> ExpirationDate {
+    let dt = chrono::Utc::now() + chrono::Duration::days(30);
+    ExpirationDate::DateTime(dt)
+}
+
+fn build_days_variant() -> ExpirationDate {
+    let days = "30.0".parse::<positive::Positive>().expect("test fixture");
+    ExpirationDate::Days(days)
+}
+
+fn bench_get_days(c: &mut Criterion) {
+    let days_variant = build_days_variant();
+    let dt_variant = build_datetime_variant();
+
+    c.bench_function("get_days/days_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(&days_variant).get_days());
+        });
+    });
+
+    c.bench_function("get_days/datetime_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(&dt_variant).get_days());
+        });
+    });
+}
+
+fn bench_get_years(c: &mut Criterion) {
+    let days_variant = build_days_variant();
+    let dt_variant = build_datetime_variant();
+
+    c.bench_function("get_years/days_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(&days_variant).get_years());
+        });
+    });
+
+    c.bench_function("get_years/datetime_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(&dt_variant).get_years());
+        });
+    });
+}
+
+criterion_group!(benches, bench_get_days, bench_get_years);
+criterion_main!(benches);

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,0 +1,59 @@
+//! Benchmarks for [`ExpirationDate::from_string`] covering every input
+//! shape the parser advertises in its docs.
+//!
+//! Compile only via `cargo bench --no-run`; run locally with
+//! `cargo bench --bench parser` when measuring changes. Every input is
+//! wrapped in [`black_box`] so the optimizer cannot elide the parse.
+
+#![allow(missing_docs)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use expiration_date::ExpirationDate;
+
+fn bench_from_string(c: &mut Criterion) {
+    c.bench_function("from_string/iso_date", |b| {
+        b.iter(|| {
+            let _ = black_box(ExpirationDate::from_string(black_box("2025-12-31")));
+        });
+    });
+
+    c.bench_function("from_string/dd_mm_yyyy", |b| {
+        b.iter(|| {
+            let _ = black_box(ExpirationDate::from_string(black_box("31-12-2025")));
+        });
+    });
+
+    // Note: "20251231" actually parses as Days(20251231.0) because the
+    // parser tries `Positive` first. The benchmark still exercises the
+    // numeric fast path which is part of the hot surface.
+    c.bench_function("from_string/yyyymmdd_numeric", |b| {
+        b.iter(|| {
+            let _ = black_box(ExpirationDate::from_string(black_box("20251231")));
+        });
+    });
+
+    c.bench_function("from_string/rfc3339", |b| {
+        b.iter(|| {
+            let _ = black_box(ExpirationDate::from_string(black_box(
+                "2025-12-31T18:30:00Z",
+            )));
+        });
+    });
+
+    c.bench_function("from_string/utc_suffix", |b| {
+        b.iter(|| {
+            let _ = black_box(ExpirationDate::from_string(black_box(
+                "2025-12-31 18:30:00 UTC",
+            )));
+        });
+    });
+
+    c.bench_function("from_string/numeric_days", |b| {
+        b.iter(|| {
+            let _ = black_box(ExpirationDate::from_string(black_box("30.0")));
+        });
+    });
+}
+
+criterion_group!(benches, bench_from_string);
+criterion_main!(benches);

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,0 +1,68 @@
+//! Benchmarks for the hand-written serde impls on [`ExpirationDate`].
+//!
+//! The tagged-map wire shape (`{"days": N}` / `{"datetime": "..."}`) is
+//! a semver contract, so serialization and deserialization speed matter
+//! for any caller persisting or reading these values in bulk.
+
+#![allow(missing_docs)]
+#![allow(clippy::expect_used)]
+
+use chrono::{TimeZone, Utc};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use expiration_date::ExpirationDate;
+
+fn build_days_variant() -> ExpirationDate {
+    let days = "30.0".parse::<positive::Positive>().expect("test fixture");
+    ExpirationDate::Days(days)
+}
+
+fn build_datetime_variant() -> ExpirationDate {
+    let dt = Utc
+        .with_ymd_and_hms(2025, 12, 31, 18, 30, 0)
+        .single()
+        .expect("test fixture");
+    ExpirationDate::DateTime(dt)
+}
+
+fn bench_serialize(c: &mut Criterion) {
+    let days_variant = build_days_variant();
+    let dt_variant = build_datetime_variant();
+
+    c.bench_function("serde/to_string/days_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(serde_json::to_string(black_box(&days_variant)));
+        });
+    });
+
+    c.bench_function("serde/to_string/datetime_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(serde_json::to_string(black_box(&dt_variant)));
+        });
+    });
+}
+
+fn bench_deserialize(c: &mut Criterion) {
+    let days_variant = build_days_variant();
+    let dt_variant = build_datetime_variant();
+    let days_json = serde_json::to_string(&days_variant).expect("test fixture");
+    let dt_json = serde_json::to_string(&dt_variant).expect("test fixture");
+
+    c.bench_function("serde/from_str/days_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(serde_json::from_str::<ExpirationDate>(black_box(
+                days_json.as_str(),
+            )));
+        });
+    });
+
+    c.bench_function("serde/from_str/datetime_variant", |b| {
+        b.iter(|| {
+            let _ = black_box(serde_json::from_str::<ExpirationDate>(black_box(
+                dt_json.as_str(),
+            )));
+        });
+    });
+}
+
+criterion_group!(benches, bench_serialize, bench_deserialize);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Three criterion bench files covering the hot paths:

- `benches/parser.rs` — `from_string` for ISO date, DD-MM-YYYY, YYYYMMDD, RFC3339, UTC suffix, numeric days
- `benches/conversion.rs` — `get_days` and `get_years` on both variants
- `benches/serde.rs` — `serde_json::to_string` / `from_str` for both variants

Adds `criterion 0.5` (html_reports) as a dev-dependency, three `[[bench]]` entries with `harness = false`, `make bench` target, and `README` mentions.

Closes #11.

## Test plan

- [x] `cargo build --benches --all-features` clean
- [x] `cargo bench --all-features --no-run` compiles all benches
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — all tests pass
- [x] `cargo test --no-default-features` — all tests pass