### PR TITLE
ci: make codecov upload tolerant of missing token

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -99,7 +99,10 @@ jobs:
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@v5
         with:
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          # Best-effort upload: Dependabot PRs cannot access secrets, so the
+          # upload would otherwise fail with "Token required because branch
+          # is protected". Pushes to main still succeed because the token is
+          # available there.
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Dependabot PRs (#19–#22) all fail because the Codecov upload step has `fail_ci_if_error: true` but Dependabot can't access `secrets.CODECOV_TOKEN`. Codecov v5 then errors with `Token required because branch is protected`.

This PR sets `fail_ci_if_error: false` (best-effort upload) and passes the token via `with: token:` (preferred on codecov-action v5).

After merge, the open Dependabot PRs need to be rebased so they pick up the workflow fix.

## Test plan

- [x] Verify codecov step still runs on main pushes (token available)
- [ ] After merge: rebase Dependabot PRs and confirm they go green